### PR TITLE
Fix /data/db volume mount point

### DIFF
--- a/commands
+++ b/commands
@@ -42,7 +42,7 @@ case "$1" in
 
     dokku_log_info1 "Starting container"
     SERVICE_NAME=$(get_service_name "$SERVICE")
-    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/data" -d --restart always --label dokku=service --label dokku.service=mongo "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" mongod --storageEngine wiredTiger --auth)
+    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/data/db" -d --restart always --label dokku=service --label dokku.service=mongo "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" mongod --storageEngine wiredTiger --auth)
     echo "$ID" > "$SERVICE_ROOT/ID"
 
     dokku_log_verbose_quiet "Waiting for container to be ready"


### PR DESCRIPTION
Mongo images on dockerhub uses `/data/db` [volume](https://github.com/docker-library/mongo/blob/d356e7da1cf470d732a5e92b41eae66aa09e7c77/3.0/Dockerfile#L41) and not `/data`.

After upgrading, users will need to manually copy `/var/lib/docker/volumes/../_data` to `/var/lib/dokku/services/mongo/<app>/data`

You can get the current mount points using `docker inspect <container-id>`

```
"Mounts": [
    {
        "Source": "/var/lib/dokku/services/mongo/<app>/data",
        "Destination": "/data",
        "Mode": "",
        "RW": true
    },
    {
        "Name": "bda013c6b4699687eb8a8e8e68440838cfedef62ab4be454bc13d0f66eab1279",
        "Source": "/var/lib/docker/volumes/bda013c6b4699687eb8a8e8e68440838cfedef62ab4be454bc13d0f66eab1279/_data",
        "Destination": "/data/db",
        "Driver": "local",
        "Mode": "",
        "RW": true
    }
],
```
