### PR TITLE
Requesting clarification to README.md for prior version usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Official mongo plugin for dokku. Currently defaults to installing [mongo 3.0.6](
 ## installation
 
 ```shell
+# set the mongo image version that you need before you import the plugin if you plan on using something other than the default version.
+export MONGO_IMAGE_VERSION="3.0.6"
+
 # on 0.3.x
 cd /var/lib/dokku/plugins
 git clone https://github.com/dokku/dokku-mongo.git mongo


### PR DESCRIPTION
MONGO_IMAGE_VERSION needs to be set to the proper version number before the plugin is installed if the user is planning on using something other than the default version.