### PR TITLE
Mongodump 2.6 compatibility

### DIFF
--- a/commands
+++ b/commands
@@ -117,7 +117,7 @@ case "$1" in
     PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
 
     [[ -n $SSH_TTY ]] && stty -opost
-    docker exec "$SERVICE_NAME" bash -c "DIR=\$(mktemp -d) && mongodump -d $SERVICE -o=\"\$DIR\" -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$SERVICE\" && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
+    docker exec "$SERVICE_NAME" bash -c "DIR=\$(mktemp -d) && mongodump -d $SERVICE -o \"\$DIR\" -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$SERVICE\" && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
     [[ -n $SSH_TTY ]] && stty opost
     ;;
 

--- a/commands
+++ b/commands
@@ -117,7 +117,7 @@ case "$1" in
     PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
 
     [[ -n $SSH_TTY ]] && stty -opost
-    docker exec "$SERVICE_NAME" bash -c "DIR=\$(mktemp -d) && mongodump -d $SERVICE -o \"\$DIR\" -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$SERVICE\" && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
+    docker exec "$SERVICE_NAME" bash -c "DIR=\$(mktemp -d) && mongodump -d $SERVICE -o \"\$DIR\" -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$SERVICE\" 1>&2 && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
     [[ -n $SSH_TTY ]] && stty opost
     ;;
 

--- a/tests/service_export.bats
+++ b/tests/service_export.bats
@@ -25,6 +25,6 @@ teardown() {
   export ECHO_DOCKER_COMMAND="true"
   run dokku "$PLUGIN_COMMAND_PREFIX:export" l
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
-  assert_output "docker exec dokku.mongo.l bash -c DIR=\$(mktemp -d) && mongodump -d l -o=\"\$DIR\" -u \"l\" -p \"$password\" --authenticationDatabase \"l\" && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
+  assert_output "docker exec dokku.mongo.l bash -c DIR=\$(mktemp -d) && mongodump -d l -o \"\$DIR\" -u \"l\" -p \"$password\" --authenticationDatabase \"l\" && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
 }
 

--- a/tests/service_export.bats
+++ b/tests/service_export.bats
@@ -25,6 +25,6 @@ teardown() {
   export ECHO_DOCKER_COMMAND="true"
   run dokku "$PLUGIN_COMMAND_PREFIX:export" l
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
-  assert_output "docker exec dokku.mongo.l bash -c DIR=\$(mktemp -d) && mongodump -d l -o \"\$DIR\" -u \"l\" -p \"$password\" --authenticationDatabase \"l\" && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
+  assert_output "docker exec dokku.mongo.l bash -c DIR=\$(mktemp -d) && mongodump -d l -o \"\$DIR\" -u \"l\" -p \"$password\" --authenticationDatabase \"l\" 1>&2 && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
 }
 


### PR DESCRIPTION
I am using mongo 2.6 and export was not working. I found 2 quick fixes that fixed 2.6.11 but did not break the default 3.x in my testing.