### PR TITLE
Adding roles for admin user

### DIFF
--- a/functions
+++ b/functions
@@ -382,7 +382,7 @@ service_create_container() {
   dokku_log_verbose_quiet "Waiting for container to be ready"
   docker run --rm --link "$SERVICE_NAME:$PLUGIN_COMMAND_PREFIX" dokkupaas/wait > /dev/null
 
-  echo "db.createUser({user:'admin',pwd:'$ROOTPASSWORD',roles:[{role:'userAdminAnyDatabase',db:'admin'}]})" | docker exec -i "$SERVICE_NAME" mongo admin > /dev/null
+  echo "db.createUser({user:'admin',pwd:'$ROOTPASSWORD',roles:[{role:'userAdminAnyDatabase',db:'admin'},{role:'__system',db:'admin'},{role:'root',db:'admin'}]})" | docker exec -i "$SERVICE_NAME" mongo admin > /dev/null
   echo "db.createUser({user:'$SERVICE',pwd:'$PASSWORD',roles:[{role:'readWrite',db:'$SERVICE'}]})" | docker exec -i "$SERVICE_NAME" mongo -u admin -p "$ROOTPASSWORD" --authenticationDatabase admin "$SERVICE" > /dev/null
   dokku_log_info2 "$PLUGIN_SERVICE container created: $SERVICE"
   service_info "$SERVICE"


### PR DESCRIPTION
Rights missing to perform system.version actions:
```> db.system.version.remove({})
WriteResult({
	"writeError" : {
		"code" : 13,
		"errmsg" : "not authorized on admin to execute command { delete: \"system.version\", deletes: [ { q: {}, limit: 0.0 } ], ordered: true }"
	}
})```