### PR TITLE
Use --archive --gzip in import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dokku mongo (beta) [![Build Status](https://img.shields.io/travis/dokku/dokku-mongo.svg?branch=master "Build Status")](https://travis-ci.org/dokku/dokku-mongo) [![IRC Network](https://img.shields.io/badge/irc-freenode-blue.svg "IRC Freenode")](https://webchat.freenode.net/?channels=dokku)
 
-Official mongo plugin for dokku. Currently defaults to installing [mongo 3.2.9](https://hub.docker.com/_/mongo/).
+Official mongo plugin for dokku. Currently defaults to installing [mongo 3.4.4](https://hub.docker.com/_/mongo/).
 
 ## requirements
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dokku mongo (beta) [![Build Status](https://img.shields.io/travis/dokku/dokku-mongo.svg?branch=master "Build Status")](https://travis-ci.org/dokku/dokku-mongo) [![IRC Network](https://img.shields.io/badge/irc-freenode-blue.svg "IRC Freenode")](https://webchat.freenode.net/?channels=dokku)
 
-Official mongo plugin for dokku. Currently defaults to installing [mongo 3.4.4](https://hub.docker.com/_/mongo/).
+Official mongo plugin for dokku. Currently defaults to installing [mongo 3.4.12](https://hub.docker.com/_/mongo/).
 
 ## requirements
 

--- a/config
+++ b/config
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 export MONGO_IMAGE=${MONGO_IMAGE:="mongo"}
-export MONGO_IMAGE_VERSION=${MONGO_IMAGE_VERSION:="3.2.9"}
+export MONGO_IMAGE_VERSION=${MONGO_IMAGE_VERSION:="3.4.4"}
 export MONGO_ROOT=${MONGO_ROOT:="/var/lib/dokku/services/mongo"}
 
 export PLUGIN_COMMAND_PREFIX="mongo"

--- a/config
+++ b/config
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 export MONGO_IMAGE=${MONGO_IMAGE:="mongo"}
-export MONGO_IMAGE_VERSION=${MONGO_IMAGE_VERSION:="3.4.4"}
+export MONGO_IMAGE_VERSION=${MONGO_IMAGE_VERSION:="3.4.12"}
 export MONGO_ROOT=${MONGO_ROOT:="/var/lib/dokku/services/mongo"}
 
 export PLUGIN_COMMAND_PREFIX="mongo"

--- a/functions
+++ b/functions
@@ -114,7 +114,7 @@ service_import() {
   if [[ -t 0 ]]; then
     dokku_log_fail "No data provided on stdin."
   fi
-  docker exec -i "$SERVICE_NAME" bash -c "mongorestore -d $SERVICE -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$SERVICE\" --gzip --archive"
+  docker exec -i "$SERVICE_NAME" bash -c "mongorestore -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$SERVICE\" --gzip --archive --nsFrom '\$db\$.\$coll\$' --nsTo '$SERVICE.\$coll\$'"
 }
 
 service_start() {

--- a/functions
+++ b/functions
@@ -99,7 +99,7 @@ service_export() {
   local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
 
   [[ -n $SSH_TTY ]] && stty -opost
-  docker exec "$SERVICE_NAME" bash -c "mongodump -d $SERVICE -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$SERVICE\" --gzip --archive"
+  docker exec "$SERVICE_NAME" bash -c "mongodump -d $SERVICE -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$SERVICE\" --gzip --archive 2>/dev/null"
   status=$?
   [[ -n $SSH_TTY ]] && stty opost
   exit $status

--- a/functions
+++ b/functions
@@ -99,7 +99,7 @@ service_export() {
   local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
 
   [[ -n $SSH_TTY ]] && stty -opost
-  docker exec "$SERVICE_NAME" bash -c "DIR=\$(mktemp -d) && mongodump -d $SERVICE -o \"\$DIR\" -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$SERVICE\" 1>&2 && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
+  docker exec "$SERVICE_NAME" bash -c "mongodump -d $SERVICE -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$SERVICE\" --gzip --archive"
   status=$?
   [[ -n $SSH_TTY ]] && stty opost
   exit $status
@@ -114,7 +114,7 @@ service_import() {
   if [[ -t 0 ]]; then
     dokku_log_fail "No data provided on stdin."
   fi
-  docker exec -i "$SERVICE_NAME" bash -c "DIR=\$(mktemp -d) && tar xf - -C \"\$DIR\" && mongorestore -d $SERVICE -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$SERVICE\" \$(find \"\$DIR\" -mindepth 1 -maxdepth 1 -type d | head -n1) && rm -rf \"\$DIR\""
+  docker exec -i "$SERVICE_NAME" bash -c "mongorestore -d $SERVICE -u \"$SERVICE\" -p \"$PASSWORD\" --authenticationDatabase \"$SERVICE\" --gzip --archive"
 }
 
 service_start() {

--- a/tests/bin/docker
+++ b/tests/bin/docker
@@ -19,7 +19,7 @@ case "$1" in
     echo "dokkupaas/docker-grafana-graphite    3.0.1               75dcd48a5eef        2 days ago          936.4 MB"
     echo "mariadb                              10.1.16             f2485761e714        2 days ago          302.2 MB"
     echo "memcached                            1.4.31              8a05b51f8876        2 days ago          132.4 MB"
-    echo "mongo                                3.4.4               12eadb136159        2 days ago          291.1 MB"
+    echo "mongo                                3.4.12               12eadb136159        2 days ago          291.1 MB"
     echo "mysql                                5.7.12              57d56ac47bed        2 days ago          321.3 MB"
     echo "nats                                 0.9.4               9216d5a4eec8        2 days ago          109.3 MB"
     echo "postgres                             9.5.4               6412eb70175e        2 days ago          265.7 MB"
@@ -68,7 +68,7 @@ case "$1" in
       echo '76a0e7154483        dokkupaas/docker-grafana-graphite:3.0.1    "/usr/bin/supervisor"      11 seconds ago       Up 10 seconds       80/tcp, 2003/tcp, 8126/tcp, 8125/udp       dokku.graphite.l'
       echo '94df08fe5550        mariadb:10.1.16                            "/docker-entrypoint."      11 seconds ago       Up 10 seconds       3306/tcp                                   dokku.mariadb.l'
       echo 'ef27fec191ba        memcached:1.4.31                           "/entrypoint.sh memc"      11 seconds ago       Up 10 seconds       11211/tcp                                  dokku.memcached.l'
-      echo 'c0f74fc90377        mongo:3.4.4                                "/entrypoint.sh mong"      11 seconds ago       Up 10 seconds       27017/tcp                                  dokku.mongo.l'
+      echo 'c0f74fc90377        mongo:3.4.12                                "/entrypoint.sh mong"      11 seconds ago       Up 10 seconds       27017/tcp                                  dokku.mongo.l'
       echo '0f33b1c86da9        mysql:5.7.12                               "/entrypoint.sh mysq"      11 seconds ago       Up 10 seconds       3306/tcp                                   dokku.mysql.l'
       echo '9f10b6dc12d5        nats:0.9.4                                 "/entrypoint.sh redi"      11 seconds ago       Up 10 seconds       4222/tcp                                   dokku.nats.l'
       echo '7f899b723c08        postgres:9.5.4                             "/docker-entrypoint."      11 seconds ago       Up 10 seconds       5432/tcp                                   dokku.postgres.l'

--- a/tests/bin/docker
+++ b/tests/bin/docker
@@ -19,7 +19,7 @@ case "$1" in
     echo "dokkupaas/docker-grafana-graphite    3.0.1               75dcd48a5eef        2 days ago          936.4 MB"
     echo "mariadb                              10.1.16             f2485761e714        2 days ago          302.2 MB"
     echo "memcached                            1.4.31              8a05b51f8876        2 days ago          132.4 MB"
-    echo "mongo                                3.2.9               12eadb136159        2 days ago          291.1 MB"
+    echo "mongo                                3.4.4               12eadb136159        2 days ago          291.1 MB"
     echo "mysql                                5.7.12              57d56ac47bed        2 days ago          321.3 MB"
     echo "nats                                 0.9.4               9216d5a4eec8        2 days ago          109.3 MB"
     echo "postgres                             9.5.4               6412eb70175e        2 days ago          265.7 MB"
@@ -68,7 +68,7 @@ case "$1" in
       echo '76a0e7154483        dokkupaas/docker-grafana-graphite:3.0.1    "/usr/bin/supervisor"      11 seconds ago       Up 10 seconds       80/tcp, 2003/tcp, 8126/tcp, 8125/udp       dokku.graphite.l'
       echo '94df08fe5550        mariadb:10.1.16                            "/docker-entrypoint."      11 seconds ago       Up 10 seconds       3306/tcp                                   dokku.mariadb.l'
       echo 'ef27fec191ba        memcached:1.4.31                           "/entrypoint.sh memc"      11 seconds ago       Up 10 seconds       11211/tcp                                  dokku.memcached.l'
-      echo 'c0f74fc90377        mongo:3.2.9                                "/entrypoint.sh mong"      11 seconds ago       Up 10 seconds       27017/tcp                                  dokku.mongo.l'
+      echo 'c0f74fc90377        mongo:3.4.4                                "/entrypoint.sh mong"      11 seconds ago       Up 10 seconds       27017/tcp                                  dokku.mongo.l'
       echo '0f33b1c86da9        mysql:5.7.12                               "/entrypoint.sh mysq"      11 seconds ago       Up 10 seconds       3306/tcp                                   dokku.mysql.l'
       echo '9f10b6dc12d5        nats:0.9.4                                 "/entrypoint.sh redi"      11 seconds ago       Up 10 seconds       4222/tcp                                   dokku.nats.l'
       echo '7f899b723c08        postgres:9.5.4                             "/docker-entrypoint."      11 seconds ago       Up 10 seconds       5432/tcp                                   dokku.postgres.l'

--- a/tests/service_export.bats
+++ b/tests/service_export.bats
@@ -27,7 +27,7 @@ teardown() {
   run dokku "$PLUGIN_COMMAND_PREFIX:export" l
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
   assert_exit_status 0
-  assert_output "docker exec dokku.mongo.l bash -c mongodump -d l -u \"l\" -p \"$password\" --authenticationDatabase \"l\" --gzip --archive"
+  assert_output "docker exec dokku.mongo.l bash -c mongodump -d l -u \"l\" -p \"$password\" --authenticationDatabase \"l\" --gzip --archive 2>/dev/null"
 }
 
 @test "($PLUGIN_COMMAND_PREFIX:export) success without SSH_TTY" {
@@ -36,5 +36,5 @@ teardown() {
   run dokku "$PLUGIN_COMMAND_PREFIX:export" l
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
   assert_exit_status 0
-  assert_output "docker exec dokku.mongo.l bash -c mongodump -d l -u \"l\" -p \"$password\" --authenticationDatabase \"l\" --gzip --archive"
+  assert_output "docker exec dokku.mongo.l bash -c mongodump -d l -u \"l\" -p \"$password\" --authenticationDatabase \"l\" --gzip --archive 2>/dev/null"
 }

--- a/tests/service_export.bats
+++ b/tests/service_export.bats
@@ -27,7 +27,7 @@ teardown() {
   run dokku "$PLUGIN_COMMAND_PREFIX:export" l
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
   assert_exit_status 0
-  assert_output "docker exec dokku.mongo.l bash -c DIR=\$(mktemp -d) && mongodump -d l -o \"\$DIR\" -u \"l\" -p \"$password\" --authenticationDatabase \"l\" 1>&2 && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
+  assert_output "docker exec dokku.mongo.l bash -c mongodump -d l -u \"l\" -p \"$password\" --authenticationDatabase \"l\" --gzip --archive"
 }
 
 @test "($PLUGIN_COMMAND_PREFIX:export) success without SSH_TTY" {
@@ -36,5 +36,5 @@ teardown() {
   run dokku "$PLUGIN_COMMAND_PREFIX:export" l
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
   assert_exit_status 0
-  assert_output "docker exec dokku.mongo.l bash -c DIR=\$(mktemp -d) && mongodump -d l -o \"\$DIR\" -u \"l\" -p \"$password\" --authenticationDatabase \"l\" 1>&2 && tar cf - -C \"\$DIR\" . && rm -rf \"\$DIR\""
+  assert_output "docker exec dokku.mongo.l bash -c mongodump -d l -u \"l\" -p \"$password\" --authenticationDatabase \"l\" --gzip --archive"
 }

--- a/tests/service_import.bats
+++ b/tests/service_import.bats
@@ -32,6 +32,5 @@ teardown() {
   export ECHO_DOCKER_COMMAND="true"
   run dokku "$PLUGIN_COMMAND_PREFIX:import" l < "$PLUGIN_DATA_ROOT/fake.dump.tar"
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
-  assert_output "docker exec -i dokku.mongo.l bash -c DIR=\$(mktemp -d) && tar xf - -C \"\$DIR\" && mongorestore -d l -u \"l\" -p \"$password\" --authenticationDatabase \"l\" \$(find \"\$DIR\" -mindepth 1 -maxdepth 1 -type d | head -n1) && rm -rf \"\$DIR\""
+  assert_output "docker exec -i dokku.mongo.l bash -c mongorestore -d l -u \"l\" -p \"$password\" --authenticationDatabase \"l\" --gzip --archive"
 }
-

--- a/tests/service_import.bats
+++ b/tests/service_import.bats
@@ -32,5 +32,5 @@ teardown() {
   export ECHO_DOCKER_COMMAND="true"
   run dokku "$PLUGIN_COMMAND_PREFIX:import" l < "$PLUGIN_DATA_ROOT/fake.dump.tar"
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
-  assert_output "docker exec -i dokku.mongo.l bash -c mongorestore -d l -u \"l\" -p \"$password\" --authenticationDatabase \"l\" --gzip --archive"
+  assert_output "docker exec -i dokku.mongo.l bash -c mongorestore -u \"l\" -p \"$password\" --authenticationDatabase \"l\" --gzip --archive --nsFrom '\$db\$.\$coll\$' --nsTo 'l.\$coll\$'"
 }

--- a/tests/service_list.bats
+++ b/tests/service_list.bats
@@ -11,20 +11,20 @@ teardown() {
 
 @test "($PLUGIN_COMMAND_PREFIX:list) with no exposed ports, no linked apps" {
   run dokku "$PLUGIN_COMMAND_PREFIX:list"
-  assert_contains "${lines[*]}" "l     mongo:3.2.9  running  -              -"
+  assert_contains "${lines[*]}" "l     mongo:3.4.4  running  -              -"
 }
 
 @test "($PLUGIN_COMMAND_PREFIX:list) with exposed ports" {
   dokku "$PLUGIN_COMMAND_PREFIX:expose" l 4242 4243 4244 4245
   run dokku "$PLUGIN_COMMAND_PREFIX:list"
-  assert_contains "${lines[*]}" "l     mongo:3.2.9  running  27017->4242 27018->4243 27019->4244 28017->4245   -"
+  assert_contains "${lines[*]}" "l     mongo:3.4.4  running  27017->4242 27018->4243 27019->4244 28017->4245   -"
 }
 
 @test "($PLUGIN_COMMAND_PREFIX:list) with linked app" {
   dokku apps:create my_app
   dokku "$PLUGIN_COMMAND_PREFIX:link" l my_app
   run dokku "$PLUGIN_COMMAND_PREFIX:list"
-  assert_contains "${lines[*]}" "l     mongo:3.2.9  running  -              my_app"
+  assert_contains "${lines[*]}" "l     mongo:3.4.4  running  -              my_app"
   dokku --force apps:destroy my_app
 }
 

--- a/tests/service_list.bats
+++ b/tests/service_list.bats
@@ -11,20 +11,20 @@ teardown() {
 
 @test "($PLUGIN_COMMAND_PREFIX:list) with no exposed ports, no linked apps" {
   run dokku "$PLUGIN_COMMAND_PREFIX:list"
-  assert_contains "${lines[*]}" "l     mongo:3.4.4  running  -              -"
+  assert_contains "${lines[*]}" "l     mongo:3.4.12  running  -              -"
 }
 
 @test "($PLUGIN_COMMAND_PREFIX:list) with exposed ports" {
   dokku "$PLUGIN_COMMAND_PREFIX:expose" l 4242 4243 4244 4245
   run dokku "$PLUGIN_COMMAND_PREFIX:list"
-  assert_contains "${lines[*]}" "l     mongo:3.4.4  running  27017->4242 27018->4243 27019->4244 28017->4245   -"
+  assert_contains "${lines[*]}" "l     mongo:3.4.12  running  27017->4242 27018->4243 27019->4244 28017->4245   -"
 }
 
 @test "($PLUGIN_COMMAND_PREFIX:list) with linked app" {
   dokku apps:create my_app
   dokku "$PLUGIN_COMMAND_PREFIX:link" l my_app
   run dokku "$PLUGIN_COMMAND_PREFIX:list"
-  assert_contains "${lines[*]}" "l     mongo:3.4.4  running  -              my_app"
+  assert_contains "${lines[*]}" "l     mongo:3.4.12  running  -              my_app"
   dokku --force apps:destroy my_app
 }
 


### PR DESCRIPTION
- ~~Fixes tests on OS X by using gnu readline~~
- Updated default mongo version from 3.2.9 to 3.4.12
- `mongo:export` uses `--archive --gzip` (requires mongo 3.2+)
- `mongo:export` silences STDERR since STDERR is converted to STDOUT when using `ssh -t`, also other `*:export` plugins are silent.
- `mongo:import` uses `--archive --gzip --nsFrom ... --nsTo ...` (requires mongo 3.4+)

Fixes #70, #84.

I have tested import/export directly on the server and also through ssh -t. it works.